### PR TITLE
Better unmount behavior on OSX

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ class Fuse extends Nanoresource {
 
   static unmount (mnt, cb) {
     mnt = JSON.stringify(mnt)
-    const cmd = IS_OSX ? `diskutil umount ${mnt}` : `fusermount -uz ${mnt}`
+    const cmd = IS_OSX ? `diskutil unmount force ${mnt}` : `fusermount -uz ${mnt}`
     exec(cmd, err => {
       if (err) return cb(err)
       return cb(null)
@@ -320,8 +320,11 @@ class Fuse extends Nanoresource {
   _close (cb) {
     const self = this
 
-    Fuse.unmount(this.mnt, () => {
-      // Even if the unmount command fails, do the native unmount.
+    Fuse.unmount(this.mnt, err => {
+      if (err) {
+        err.unmountFailure = true
+        return cb(err)
+      }
       nativeUnmount()
     })
 

--- a/test/fixtures/simple-fs.js
+++ b/test/fixtures/simple-fs.js
@@ -1,0 +1,34 @@
+const stat = require('./stat')
+const Fuse = require('../../')
+
+module.exports = function (tests = {}) {
+  return {
+    readdir: function (path, cb) {
+      if (tests.readdir) tests.readdir(path)
+      if (path === '/') return process.nextTick(cb, null, ['test'])
+      return process.nextTick(cb, Fuse.ENOENT)
+    },
+    getattr: function (path, cb) {
+      if (tests.getattr) tests.getattr(path)
+      if (path === '/') return process.nextTick(cb, null, stat({ mode: 'dir', size: 4096 }))
+      if (path === '/test') return process.nextTick(cb, null, stat({ mode: 'file', size: 11 }))
+      return process.nextTick(cb, Fuse.ENOENT)
+    },
+    open: function (path, flags, cb) {
+      if (tests.open) tests.open(path, flags)
+      return process.nextTick(cb, 0, 42)
+    },
+    release: function (path, fd, cb) {
+      if (tests.release) tests.release(path, fd)
+      return process.nextTick(cb, 0)
+    },
+    read: function (path, fd, buf, len, pos, cb) {
+      if (tests.read) tests.read(path, fd, buf, len, pos)
+      var str = 'hello world'.slice(pos, pos + len)
+      if (!str) return process.nextTick(cb, 0)
+      buf.write(str)
+      return process.nextTick(cb, str.length)
+    }
+  }
+}
+


### PR DESCRIPTION
If we call `diskutil unmount force (mountpoint)` instead of just `diskutil unmount (mountpoint)`, it will unmount even if terminals and Finders are open on that mountpoint.

Added a few OSX-specific tests to cover this scenario.