### PR TITLE
fix: remove incorrect flush parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -512,8 +512,8 @@ class Fuse extends Nanoresource {
     })
   }
 
-  _op_flush (signal, path, datasync, fd) {
-    this.ops.flush(path, datasync, fd, err => {
+  _op_flush (signal, path, fd) {
+    this.ops.flush(path, fd, err => {
       return signal(err)
     })
   }


### PR DESCRIPTION
I have some code like this

```typescript
flush (path, fd, reply) {
  debug("flush", { path, fd })

  writer.flush(path)
    .then(() => reply(0))
    .catch(err => {
      debug({ err })
      reply(errorToFuseCode(err))
    })
}
```

but it produces

> UnhandledPromiseRejectionWarning: TypeError: reply is not a function

because an extra `datasync` parameter gets in the way of the documented `reply` function.

This change removes the incorrect extra parameter.