### PR TITLE
malloc and track thread_local buffers from js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_deploy:
 - ARCHIVE_NAME="${TRAVIS_TAG:-latest}-$TRAVIS_OS_NAME.tar"
 - npm run prebuild
 - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then PREBUILD_ARCH=ia32 npm run prebuild; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then PREBUILD_ARCH=ia32 npm run prebuild; fi
 - cd prebuilds && tar cvf "../$ARCHIVE_NAME" . && cd ..
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,6 @@ before_deploy:
 - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then PREBUILD_ARCH=ia32 npm run prebuild; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then PREBUILD_ARCH=ia32 npm run prebuild; fi
 - cd prebuilds && tar cvf "../$ARCHIVE_NAME" . && cd ..
+
+cache:
+  npm: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,14 @@ before_deploy:
 
 cache:
   npm: false
+
+deploy:
+  provider: releases
+  draft: false
+  prerelease: true
+  api_key:
+    secure: "KPn3xR4LWcg/H259aSZh26XX0eapR88xSNUkBmEri/sCJSyZ0+asLZSv/HDD3KJP4HeuIKsQc0v8fcebD83fkvaSvlUzSppMQgniwuGC1cAefbrgZDwmJJ/n+lE8Wr9x4adOBTgICS5Uc8LlZ1PuJGm4mmequVs29BEw9738LzN4+3NpoCoWd0FAgGF0tDTsaYL1tJqERAyNIxHS+adUPe0F2r0d2UJ7mOrW7s8Ai6e6QryFsFvA2m0Xn/pQmNO/mcq+LPcw57pWuI3Hm3Cu3W8VPJXYp/yJaFqTAn3D9Fwz4tkmbfmca4ETwZYOS3lvL/rjLQ+69SJlRRu/QfPECkZven+wwsLX/DmyGHgEWqeGWjKj/NxYOIKUKEZZCVrF8cy4j9mac+LK6bAeDZERKSxUJ9GT5WsjvV3RNKgp3MZF7mtmj4IWXfgcuwFX49oIqhzSJsucBBXlB74J7Qua5VJPEAo/7X7Q+Y9IT9JHwxXsXVF5ZNj1PMlJicVD6oKi4XCFOVxSE9wdzlBwMOlUyBGhAIzS6lmxHOELYO9C7l8t/8Zvi4a+YGvOwn0dzLb9zuA1bzqJmEB1fkQMZXHvcEY1o5jSTQ0cNn1Wx4Ck9zyLyhnZ5KRXKzGQ1du55iVOThcbl/8j6zT218SiZMMtv8ZwPy4pJt4skMGsoOZtYlE="  file: "$ARCHIVE_NAME"
+  skip_cleanup: true
+  on:
+    tags: true
+    node: 'node'

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,18 @@
     "sources": [
       "fuse-native.c"
     ],
-    "cflags": ["-rdynamic"]
+    'xcode_settings': {
+      'OTHER_CFLAGS': [
+        '-g',
+        '-O3',
+        '-Wall'
+      ]
+    },
+    'cflags': [
+      '-g',
+      '-O3',
+      '-Wall'
+    ],
   }, {
     "target_name": "postinstall",
     "type": "none",

--- a/fuse-native.c
+++ b/fuse-native.c
@@ -380,7 +380,7 @@ FUSE_METHOD(read, 6, 2, (const char *path, char *buf, size_t len, off_t offset, 
   napi_create_uint32(env, l->len, &(argv[5]));
   FUSE_UINT64_TO_INTS_ARGV(l->offset, 6)
 }, {
-  napi_detach_arraybuffer(env, argv[3]);
+  assert(napi_detach_arraybuffer(env, argv[3]) == napi_ok);
 })
 
 FUSE_METHOD(write, 6, 1, (const char *path, const char *buf, size_t len, off_t offset, struct fuse_file_info *info), {

--- a/fuse-native.c
+++ b/fuse-native.c
@@ -370,6 +370,7 @@ FUSE_METHOD(read, 6, 1, (const char *path, char *buf, size_t len, off_t offset, 
   l->path = path;
   l->buf = buf;
   l->len = len;
+  printf("making a buffer %zu %zu\n", buf, len);
   l->offset = offset;
   l->info = info;
 }, {

--- a/fuse-native.c
+++ b/fuse-native.c
@@ -183,10 +183,6 @@ static fuse_thread_locals_t* get_thread_locals();
 // Helpers
 // TODO: Extract into a separate file.
 
-static void fin (napi_env env, void *fin_data, void* fin_hint) {
-  // noop
-}
-
 static uint64_t uint32s_to_uint64 (uint32_t **ints) {
   uint64_t low = *((*ints)++);
   uint64_t high = *((*ints)++);
@@ -379,7 +375,7 @@ FUSE_METHOD(read, 6, 1, (const char *path, char *buf, size_t len, off_t offset, 
 }, {
   napi_create_string_utf8(env, l->path, NAPI_AUTO_LENGTH, &(argv[2]));
   napi_create_uint32(env, l->info->fh, &(argv[3]));
-  napi_create_external_buffer(env, l->len, (char *) l->buf, &fin, NULL, &(argv[4]));
+  napi_create_external_buffer(env, l->len, (char *) l->buf, NULL, NULL, &(argv[4]));
   napi_create_uint32(env, l->len, &(argv[5]));
   FUSE_UINT64_TO_INTS_ARGV(l->offset, 6)
 }, {
@@ -395,7 +391,7 @@ FUSE_METHOD(write, 6, 1, (const char *path, const char *buf, size_t len, off_t o
 }, {
   napi_create_string_utf8(env, l->path, NAPI_AUTO_LENGTH, &(argv[2]));
   napi_create_uint32(env, l->info->fh, &(argv[3]));
-  napi_create_external_buffer(env, l->len, (char *) l->buf, &fin, NULL, &(argv[4]));
+  napi_create_external_buffer(env, l->len, (char *) l->buf, NULL, NULL, &(argv[4]));
   napi_create_uint32(env, l->len, &(argv[5]));
   FUSE_UINT64_TO_INTS_ARGV(l->offset, 6)
 }, {
@@ -459,7 +455,7 @@ FUSE_METHOD_VOID(setxattr, 5, 0, (const char *path, const char *name, const char
 }, {
   napi_create_string_utf8(env, l->path, NAPI_AUTO_LENGTH, &(argv[2]));
   napi_create_string_utf8(env, l->name, NAPI_AUTO_LENGTH, &(argv[3]));
-  napi_create_external_buffer(env, l->size, (char *) l->value, &fin, NULL, &(argv[4]));
+  napi_create_external_buffer(env, l->size, (char *) l->value, NULL, NULL, &(argv[4]));
   napi_create_uint32(env, l->position, &(argv[5]));
   napi_create_uint32(env, l->flags, &(argv[6]));
 })
@@ -473,7 +469,7 @@ FUSE_METHOD_VOID(getxattr, 4, 0, (const char *path, const char *name, char *valu
 }, {
   napi_create_string_utf8(env, l->path, NAPI_AUTO_LENGTH, &(argv[2]));
   napi_create_string_utf8(env, l->name, NAPI_AUTO_LENGTH, &(argv[3]));
-  napi_create_external_buffer(env, l->size, (char *) l->value, &fin, NULL, &(argv[4]));
+  napi_create_external_buffer(env, l->size, (char *) l->value, NULL, NULL, &(argv[4]));
   napi_create_uint32(env, l->position, &(argv[5]));
 })
 
@@ -488,7 +484,7 @@ FUSE_METHOD_VOID(setxattr, 5, 0, (const char *path, const char *name, const char
 }, {
   napi_create_string_utf8(env, l->path, NAPI_AUTO_LENGTH, &(argv[2]));
   napi_create_string_utf8(env, l->name, NAPI_AUTO_LENGTH, &(argv[3]));
-  napi_create_external_buffer(env, l->size, (char *) l->value, &fin, NULL, &(argv[4]));
+  napi_create_external_buffer(env, l->size, (char *) l->value, NULL, NULL, &(argv[4]));
   napi_create_uint32(env, 0, &(argv[5])); // normalize apis between mac and linux
   napi_create_uint32(env, l->flags, &(argv[6]));
 })
@@ -501,7 +497,7 @@ FUSE_METHOD_VOID(getxattr, 4, 0, (const char *path, const char *name, char *valu
 }, {
   napi_create_string_utf8(env, l->path, NAPI_AUTO_LENGTH, &(argv[2]));
   napi_create_string_utf8(env, l->name, NAPI_AUTO_LENGTH, &(argv[3]));
-  napi_create_external_buffer(env, l->size, (char *) l->value, &fin, NULL, &(argv[4]));
+  napi_create_external_buffer(env, l->size, (char *) l->value, NULL, NULL, &(argv[4]));
   napi_create_uint32(env, 0, &(argv[5]));
 })
 
@@ -513,7 +509,7 @@ FUSE_METHOD_VOID(listxattr, 2, 0, (const char *path, char *list, size_t size), {
   l->size = size;
 }, {
   napi_create_string_utf8(env, l->path, NAPI_AUTO_LENGTH, &(argv[2]));
-  napi_create_external_buffer(env, l->size, l->list, &fin, NULL, &(argv[3]));
+  napi_create_external_buffer(env, l->size, l->list, NULL, NULL, &(argv[3]));
 })
 
 FUSE_METHOD_VOID(removexattr, 2, 0, (const char *path, const char *name), {

--- a/fuse-native.c
+++ b/fuse-native.c
@@ -366,7 +366,7 @@ FUSE_METHOD_VOID(releasedir, 2, 0, (const char *path, struct fuse_file_info *inf
   }
 })
 
-FUSE_METHOD(read, 6, 1, (const char *path, char *buf, size_t len, off_t offset, struct fuse_file_info *info), {
+FUSE_METHOD(read, 6, 2, (const char *path, char *buf, size_t len, off_t offset, struct fuse_file_info *info), {
   l->path = path;
   l->buf = buf;
   l->len = len;
@@ -380,7 +380,7 @@ FUSE_METHOD(read, 6, 1, (const char *path, char *buf, size_t len, off_t offset, 
   napi_create_uint32(env, l->len, &(argv[5]));
   FUSE_UINT64_TO_INTS_ARGV(l->offset, 6)
 }, {
-  // TODO: handle bytes processed?
+  napi_detach_arraybuffer(env, argv[3]);
 })
 
 FUSE_METHOD(write, 6, 1, (const char *path, const char *buf, size_t len, off_t offset, struct fuse_file_info *info), {

--- a/index.js
+++ b/index.js
@@ -464,7 +464,7 @@ class Fuse extends Nanoresource {
 
   _op_write (signal, path, fd, buf, len, offsetLow, offsetHigh) {
     this.ops.write(path, fd, buf, len, getDoubleArg(offsetLow, offsetHigh), (err, bytesWritten) => {
-      return signal(err, bytesWritten)
+      return signal(err, bytesWritten, buf.buffer)
     })
   }
 
@@ -478,7 +478,7 @@ class Fuse extends Nanoresource {
 
   _op_setxattr (signal, path, name, value, position, flags) {
     this.ops.setxattr(path, name, value, position, flags, err => {
-      return signal(err)
+      return signal(err, value.buffer)
     })
   }
 
@@ -487,9 +487,9 @@ class Fuse extends Nanoresource {
       if (!err) {
         if (!value) return signal(IS_OSX ? -93 : -61)
         value.copy(valueBuf)
-        return signal(value.length)
+        return signal(value.length, valueBuf.buffer)
       }
-      return signal(err)
+      return signal(err, valueBuf.buffer)
     })
   }
 
@@ -500,7 +500,7 @@ class Fuse extends Nanoresource {
           let size = 0
           for (const name of list) size += Buffer.byteLength(name) + 1
           size += 128 // fuse yells if we do not signal room for some mac stuff also
-          return signal(size)
+          return signal(size, listBuf.buffer)
         }
 
         let ptr = 0
@@ -510,9 +510,9 @@ class Fuse extends Nanoresource {
           listBuf[ptr++] = 0
         }
 
-        return signal(ptr)
+        return signal(ptr, listBuf.buffer)
       }
-      return signal(err)
+      return signal(err, listBuf.buffer)
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -458,7 +458,7 @@ class Fuse extends Nanoresource {
 
   _op_read (signal, path, fd, buf, len, offsetLow, offsetHigh) {
     this.ops.read(path, fd, buf, len, getDoubleArg(offsetLow, offsetHigh), (err, bytesRead) => {
-      return signal(err, bytesRead, buf)
+      return signal(err, bytesRead, buf.buffer)
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -485,7 +485,7 @@ class Fuse extends Nanoresource {
   _op_getxattr (signal, path, name, valueBuf, position) {
     this.ops.getxattr(path, name, position, (err, value) => {
       if (!err) {
-        if (!value) return signal(IS_OSX ? -93 : -61)
+        if (!value) return signal(IS_OSX ? -93 : -61, valueBuf.buffer)
         value.copy(valueBuf)
         return signal(value.length, valueBuf.buffer)
       }

--- a/index.js
+++ b/index.js
@@ -458,7 +458,7 @@ class Fuse extends Nanoresource {
 
   _op_read (signal, path, fd, buf, len, offsetLow, offsetHigh) {
     this.ops.read(path, fd, buf, len, getDoubleArg(offsetLow, offsetHigh), (err, bytesRead) => {
-      return signal(err, bytesRead)
+      return signal(err, bytesRead, buf)
     })
   }
 

--- a/test/read.js
+++ b/test/read.js
@@ -17,7 +17,7 @@ tape('read', function (t) {
       t.same(fd, 42, 'fd was passed to release')
     }
   })
-  const fuse = new Fuse(mnt, testFS, { debug: false })
+  const fuse = new Fuse(mnt, testFS, { debug: true })
   fuse.mount(function (err) {
     t.error(err, 'no error')
 

--- a/test/read.js
+++ b/test/read.js
@@ -17,7 +17,7 @@ tape('read', function (t) {
       t.same(fd, 42, 'fd was passed to release')
     }
   })
-  const fuse = new Fuse(mnt, testFS, { debug: true })
+  const fuse = new Fuse(mnt, testFS, { debug: false })
   fuse.mount(function (err) {
     t.error(err, 'no error')
 


### PR DESCRIPTION
 to avoid crashes when multiple external buffers are made from the same pointer.

- example currently runs but tests still crash
- gotta verify and node 14.3 fixes the crash