### PR TITLE
Add stat mode type constants to Fuse export

### DIFF
--- a/index.js
+++ b/index.js
@@ -771,6 +771,15 @@ Fuse.EDQUOT = -122
 Fuse.ENOMEDIUM = -123
 Fuse.EMEDIUMTYPE = -124
 
+// Mode type constants (from sys/stat.h)
+Fuse.S_IFMT = 61440
+Fuse.S_IFBLK = 24567
+Fuse.S_IFCHR = 8192
+Fuse.S_IFIFO = 4096
+Fuse.S_IFREG = 32768
+Fuse.S_IFDIR = 16384
+Fuse.S_IFLNK = 40960
+
 // Forward configuration functions through the exported class.
 Fuse.beforeMount = beforeMount
 Fuse.beforeUnmount = beforeUnmount


### PR DESCRIPTION
sys/stat.h contains bitwise constants for the various stat modes (directory, symlink, &c) that would be useful to have available as constants in Node.

From the spec: https://pubs.opengroup.org/onlinepubs/007908799/xsh/sysstat.h.html